### PR TITLE
Linting fix for missing return type on function

### DIFF
--- a/src/cdk/bootstrap.ts
+++ b/src/cdk/bootstrap.ts
@@ -88,7 +88,7 @@ export class MiraBootstrap {
    * Orchestration for `npx mira cicd` command. As an effect, CodePipeline and related services will be deployed together
    * with permission stacks deployed to the target accounts.
    */
-  async deployCi () {
+  async deployCi (): Promise<void> {
     const permissionFilePath = MiraConfig.getPermissionsFilePath()
     if (!permissionFilePath) {
       console.error('Permissions file path must be specified either in cicd config or as --file parameter.')


### PR DESCRIPTION
Fixes: 

```
src/cdk/bootstrap.ts
  91:3  warning  Missing return type on function  @typescript-eslint/explicit-function-return-type
```