### PR TITLE
Improve error message reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ dist
 !bin/*.js
 .ts-build-cache
 .mira.snapshot
+mira-error-logs*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1892,6 +1892,11 @@
       "integrity": "sha512-EoAeT1MyFWh2BJvBDEFInY714bQBbHOAucqxqqhprhbBFqr+B7fuN5T9CJqUIGDzvwubnKKRqmSo6yPo0aSpNw==",
       "dev": true
     },
+    "@types/dateformat": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dateformat/-/dateformat-3.0.1.tgz",
+      "integrity": "sha512-KlPPdikagvL6ELjWsljbyDIPzNCeliYkqRpI+zea99vBBbCIA5JNshZAwQKTON139c87y9qvTFVgkFd14rtS4g=="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -5167,6 +5172,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
+    },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -75,12 +75,14 @@
     "typescript": "^3.6.5"
   },
   "dependencies": {
+    "@types/dateformat": "^3.0.1",
     "@types/tmp": "^0.2.0",
     "ajv": "^6.12.0",
     "aws-sdk": "^2.681.0",
     "change-case": "^3.1.0",
     "colors": "^1.4.0",
     "config": "^3.3.1",
+    "dateformat": "^3.0.3",
     "docsify": "^4.11.2",
     "docsify-cli": "^4.4.0",
     "fluent-schema": "^0.10.0",

--- a/src/change-detector.ts
+++ b/src/change-detector.ts
@@ -48,7 +48,7 @@ export default class ChangeDetector {
   public async takeSnapshot (outputFile: string): Promise<null> {
     return new Promise((resolve, reject) => {
       glob(`${this.rootPath}/**`, {
-        ignore: ['**/node_modules/**', '**/cdk.out/**']
+        ignore: ['**/node_modules/**', '**/cdk.out/**', '**/mira-err**']
       }, async (err, res) => {
         if (err) {
           return reject(err)

--- a/src/error-logger.test.ts
+++ b/src/error-logger.test.ts
@@ -1,0 +1,60 @@
+import '@aws-cdk/assert/jest'
+import ErrorLogger from './error-logger'
+import fs from 'fs'
+
+describe('error logger', () => {
+  describe('constructor()', () => {
+    test('should generate correct output file', () => {
+      const logger = new ErrorLogger()
+      expect(logger.file).toMatch(/mira-errors-\d{12}\.log$/)
+    })
+  })
+
+  describe('flushMessages()', () => {
+    beforeEach(() => {
+      try {
+        // fs.unlinkSync('/tmp/my-file.log')
+      } catch (err) {
+        // do nothing
+      }
+    })
+    test('should not run if in codebuild', () => {
+      process.env.CODEBUILD_BUILD_ID = 'a-codebuild-id'
+      const logger = new ErrorLogger()
+      logger.flushMessages([
+        'message1',
+        'message2'
+      ])
+      expect(fs.existsSync(logger.file)).toBeFalsy()
+      delete process.env.CODEBUILD_BUILD_ID
+    })
+
+    test('should not run normally', () => {
+      const logger = new ErrorLogger()
+      logger.flushMessages([
+        'message1',
+        'message2'
+      ])
+      expect(fs.existsSync(logger.file)).toBeTruthy()
+      fs.unlinkSync(logger.file)
+    })
+  })
+  describe('cleanMessages()', () => {
+    test('it should delete files', async () => {
+      // create some files
+      const files = [
+        'mira-errors-123123123123.log',
+        'mira-errors-123123123124.log',
+        'mira-errors-123123123125.log'
+      ]
+      files.map((file) => {
+        fs.writeFileSync(file, 'foobar')
+      })
+      const logger = new ErrorLogger()
+      await logger.cleanMessages()
+      files.map((file) => {
+        expect(fs.existsSync(file)).toBeFalsy()
+      })
+    })
+  })
+})

--- a/src/error-logger.ts
+++ b/src/error-logger.ts
@@ -1,0 +1,38 @@
+'use strict'
+import fs from 'fs'
+import path from 'path'
+import format from 'dateformat'
+import { promisify } from 'util'
+
+const unlink = promisify(fs.unlink).bind(fs)
+const readdir = promisify(fs.readdir).bind(fs)
+export default class ErrorLogger {
+  file: string
+  constructor () {
+    const d = format(new Date(), 'yyyymmddhhss')
+    this.file = path.join(process.cwd(), `mira-errors-${d}.log`)
+  }
+
+  flushMessages (messages: string[]): void {
+    // do not run if in AWS CodeBuild
+    if (undefined === process.env.CODEBUILD_BUILD_ID) {
+      const ws = fs.createWriteStream(this.file)
+      messages.map((message) => {
+        ws.write(message)
+      })
+      ws.close()
+    }
+  }
+
+  async cleanMessages (): Promise<void> {
+    const files = await readdir(process.cwd())
+    const promises = files
+      .filter((file) => {
+        return file.match(/mira-errors-\d{12}\.log$/)
+      })
+      .map((file) => {
+        return unlink(file)
+      })
+    await Promise.all(promises)
+  }
+}


### PR DESCRIPTION
If there are errors in CloudFormation during deploy mira will show errors in screen and also save a file called `mira-errors-${TIMESTAMP}.log`

Also the command `npx mira clean` will delete these files.

Refs: #46 