### PR TITLE
Add CDK Deployment Issues to Troubleshooting

### DIFF
--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -291,7 +291,7 @@ You can resolve this by running `npx mira init` or checking your configuration f
 
 ### CDK Deployment Issues
 
-Deployment of Mira applications requires a bootstrapped CDK environment. This is created when you run the bootstrap command during initial set up (`cdk bootstrap`). This command creates a workspace where temporary assets and configurations can be stored during deployment. On rare occasions this work space can become corrupted and cause strange or unexplained failures such as permission issues. For example, on the S3 Sample application, it can manifest as a permission issue when attempting to copy files to the destination S3 bucket even though the deployment user may have administrator privilege.
+Deployment of Mira applications requires a bootstrapped CDK environment. This is created when you run the bootstrap command during initial set up (`cdk bootstrap`). This command creates a workspace where temporary assets and configurations can be stored during deployment. On rare occasions this workspace can become corrupted and cause strange or unexplained failures such as permission issues. For example, on the S3 Sample application, it can manifest as a permission issue when attempting to copy files to the destination S3 bucket even though the deployment user may have administrator privilege.
 
 If you have exhausted other possible causes and issues for a deployment failure, you can delete the CDK Toolkit and recreate it using the following steps:
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -289,6 +289,22 @@ Error: Configuration property "app.name" is not defined
 
 You can resolve this by running `npx mira init` or checking your configuration file matches the expected fields. 
 
+### CDK Deployment Issues
+
+Deployment of Mira applications requires a bootstrapped CDK environment. This is created when you run the bootstrap command during initial set up (`cdk bootstrap`). This command creates a workspace where temporary assets and configurations can be stored during deployment. On rare occasions this work space can become corrupted and cause strange or unexplained failures such as permission issues. For example, on the S3 Sample application, it can manifest as a permission issue when attempting to copy files to the destination S3 bucket even though the deployment user may have administrator privilege.
+
+If you have exhausted other possible causes and issues for a deployment failure, you can delete the CDK Toolkit and recreate it using the following steps:
+
+- Login to the AWS Web Console
+- (Optional) Switch Roles to match your deployment account
+- Go to CloudFormation Tool
+- Locate the `CDKToolkit` stack and highlight it
+- Click `Delete` from the top menu bar and confirm.
+- Once deleted you can bootstrap the CDK again as documented above.
+
+If you delete the CDK Toolkit, you will not be able to deploy until it has been recreated and any future deployments will fail. This includes any configured CI/CD pipelines.
+
+
 <!---- External links ---->
 [docs]: https://nf-mira.netlify.com/?#/
 [nvm]: https://github.com/nvm-sh/nvm

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -302,7 +302,7 @@ If you have exhausted other possible causes and issues for a deployment failure,
 - Click `Delete` from the top menu bar and confirm.
 - Once deleted you can bootstrap the CDK again as documented above.
 
-If you delete the CDK Toolkit, you will not be able to deploy until it has been recreated and any future deployments will fail. This includes any configured CI/CD pipelines.
+*Please note* that if you delete the CDK Toolkit environment, you will not be able to deploy any new or existing Mira applications until it has been recreated. This also includes any configured CI/CD pipelines.
 
 
 <!---- External links ---->

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -291,7 +291,7 @@ You can resolve this by running `npx mira init` or checking your configuration f
 
 ### CDK Deployment Issues
 
-Deployment of Mira applications requires a bootstrapped CDK environment. This is created when you run the bootstrap command during initial set up (`cdk bootstrap`). This command creates a workspace where temporary assets and configurations can be stored during deployment. On rare occasions this workspace can become corrupted and cause strange or unexplained failures such as permission issues. For example, on the S3 Sample application, it can manifest as a permission issue when attempting to copy files to the destination S3 bucket even though the deployment user may have administrator privilege.
+On rare occasions you may need to recreate the CDK bootstrap environment. This environment is created when you run `cdk bootstrap` and sets up a workspace where temporary assets and configurations can be stored during deployment. This workspace can sometimes become corrupted and cause strange or unexplained failures such as permission issues. For example, on the S3 Sample application, it can manifest as a permission issue when attempting to copy files to the destination S3 bucket even though the deployment user may have administrator privilege.
 
 If you have exhausted other possible causes and issues for a deployment failure, you can delete the CDK Toolkit and recreate it using the following steps:
 


### PR DESCRIPTION
Add a small section to the troubleshooting documentation that describes how to delete and recreate the CDK Toolkit to resolve difficult or unexplained issues.