### PR TITLE
Fix/rebuild dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc",
+    "build": "rm -rf ./dist && tsc",
     "docs": "docsify serve -p 4000 docs",
     "lint": "eslint --fix --ext .ts ./",
     "lint-ci": "eslint --ext .ts ./",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "tsc --watch",
-    "build": "rm -rf ./dist && tsc",
+    "build": "rm -rf ./dist && tsc --build --force",
     "docs": "docsify serve -p 4000 docs",
     "lint": "eslint --fix --ext .ts ./",
     "lint-ci": "eslint --ext .ts ./",


### PR DESCRIPTION
Removes the dist folder prior to a build.

See https://github.com/nearform/mira/issues/100