### PR TITLE
fix: set removal policy of CICD KMS key to destroy

### DIFF
--- a/src/cdk/constructs/cicd/index.ts
+++ b/src/cdk/constructs/cicd/index.ts
@@ -54,6 +54,7 @@ export class Cicd extends Stack {
 
     const encryptionKey = new Key(this, 'key', {
       enableKeyRotation: true,
+      // TODO might worth exposing this property as a config value
       removalPolicy: RemovalPolicy.DESTROY
     })
 

--- a/src/cdk/constructs/cicd/index.ts
+++ b/src/cdk/constructs/cicd/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@aws-cdk/aws-codepipeline-actions'
 import { Effect, PolicyStatement, Role, ServicePrincipal, User, IPrincipal } from '@aws-cdk/aws-iam'
 import { Secret } from '@aws-cdk/aws-secretsmanager'
-import { CfnOutput, Construct, Stack, StackProps, Tags } from '@aws-cdk/core'
+import { CfnOutput, Construct, Stack, StackProps, Tags, RemovalPolicy } from '@aws-cdk/core'
 import { Repository } from '@aws-cdk/aws-codecommit'
 import { IAction } from '@aws-cdk/aws-codepipeline/lib/action'
 import { UploadPublicSsh } from '../upload-public-ssh'
@@ -53,7 +53,8 @@ export class Cicd extends Stack {
     const sourceOutput = new Artifact()
 
     const encryptionKey = new Key(this, 'key', {
-      enableKeyRotation: true
+      enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.DESTROY
     })
 
     /**


### PR DESCRIPTION
Closes #99 

The encryption key created for CI/CD is set to delete with the stack