### PR TITLE
fix(permissions): add environment in permissions creation

### DIFF
--- a/src/cdk/bootstrap.ts
+++ b/src/cdk/bootstrap.ts
@@ -171,7 +171,8 @@ export class MiraBootstrap {
       const proc = this.spawn('node', commandOptions, {
         stdio: 'inherit',
         env: {
-          ...process.env
+          ...process.env,
+          NODE_ENV: account.name
         }
       })
       await new Promise((resolve, reject) => {


### PR DESCRIPTION
Fix the permissions for the CI

Without the ENV injection the CI permissions are created for the `default` account instead of `staging` and `production`