### PR TITLE
feat(params): fix uniqness

### DIFF
--- a/src/cdk/app.ts
+++ b/src/cdk/app.ts
@@ -98,13 +98,6 @@ export class MiraApp {
     return args.file.split(',')
   }
 
-  /**
-   * Gets the stack name from CLI.
-   */
-  static getStackName (): string {
-    return args.stack || 'default'
-  }
-
   static getBaseStackName (suffix?: string): string {
     return getBaseStackName(suffix)
   }

--- a/src/cdk/stack.test.ts
+++ b/src/cdk/stack.test.ts
@@ -129,14 +129,14 @@ describe('MiraStack', () => {
   it('loadParameter with fullName divided by / correctly', async () => {
     const miraStackInstance = new MiraStack(stack)
     const res = await miraStackInstance.loadParameter('Full/Name')
-    expect(res.parameterName).toBe('/default/Full/Name')
+    expect(res.parameterName).toBe('/John-MyGreatApp-default-param/Full/Name')
     expect(res.toString().split('/')[2]).toBe('FullNameParameter')
   })
 
   it('loadParameter with environment and fullName', async () => {
     const miraStackInstance = new MiraStack(stack, 'Default')
     const res = await miraStackInstance.loadParameter('Fullname')
-    expect(res.parameterName).toBe('/default/Default/Fullname')
+    expect(res.parameterName).toBe('/John-MyGreatApp-default-param/Default/Fullname')
     expect(res.toString().split('/')[2]).toBe('DefaultFullnameParameter')
   })
 })

--- a/src/cdk/stack.ts
+++ b/src/cdk/stack.ts
@@ -188,7 +188,7 @@ export class MiraStack extends NestedStack implements ExportOutputs {
       const name = nameParts.length === 1 ? nameParts[0] : nameParts[1]
 
       const id = `${baseName}${name}Parameter`
-      const parameterName = `/${MiraApp.getStackName()}/${baseName}/${name}`
+      const parameterName = `/${MiraConfig.calculateSharedResourceName('param')}/${baseName}/${name}`
 
       return { id, parameterName }
     }


### PR DESCRIPTION
In this PR:
- The create/loadParameters methods add the proper prefix to have a uniq name