### PR TITLE
Fix/inaccurate link

### DIFF
--- a/scripts/link.js
+++ b/scripts/link.js
@@ -95,7 +95,8 @@ const symlinkDependencies = (pkgDir) => {
         // NOOP
     }
     const pkg = JSON.parse(fs.readFileSync(`${__dirname}/../package.json`, 'utf8'))
-    const deps = Object.keys(Object.assign({}, pkg.dependencies, pkg.devDependencies))
+    const nodeModules = fs.readdirSync(`${__dirname}/../node_modules`)
+    const deps = Object.keys(Object.assign({}, pkg.dependencies, pkg.devDependencies)).concat(nodeModules)
     // const dependencies = fs.readdirSync(__dirname + '/../node_modules/')
     console.info(chalk.cyan('Mira Local'), 'Symlinking deps')
     deps.forEach((dep) => {


### PR DESCRIPTION
This symlinks all folders (i.e. dependencies of dependencies) when linking Mira locally to another package.  An edge may still exist where a package has been installed via a scope, e.g. `@aws-cdk/**` and some sub-package is a dependency of a dependency listed in package.json.